### PR TITLE
Edit of README and vfs example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Clone this repository into `components` subdir of yout project:
 cd ~/my_esp_idf_project
 mkdir components
 cd components
-git clone git@github.com:UncleRus/esp-idf-lua.git
+git clone https://github.com/UncleRus/esp-idf-lua.git
 ```
 
 Or clone it to any other directory and add it to your project `Makefile` or `CMakeLists.txt`:

--- a/examples/vfs/CMakeLists.txt
+++ b/examples/vfs/CMakeLists.txt
@@ -4,3 +4,5 @@ set(EXTRA_COMPONENT_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../..)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(example-lua-vfs)
+
+spiffs_create_partition_image(storage spiffs_image FLASH_IN_PROJECT)


### PR DESCRIPTION
Changed clone url from `ssh` to `https`, general auditory will have less problems cloning it. Modified vfs example by adding `spiffs_create...` into `CMakeLists.txt` allowing to use example easily with VSCode Espressif plugin.