### PR TITLE
Allow to inject LUA_32BITS.

### DIFF
--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -117,7 +117,9 @@
 /*
 @@ LUA_32BITS enables Lua with 32-bit integers and 32-bit floats.
 */
+#if !defined(LUA_32BITS)
 #define LUA_32BITS	0
+#endif
 
 
 /*


### PR DESCRIPTION
As per title, allows configuring LUA for 32 bits using
```
add_compile_definitions(LUA_32BITS)
```